### PR TITLE
Add functionality to trim whitespace and auto-press 'Enter'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 This program is designed to print text from the clipboard using Keyboard events.
 Password entry into console applications is enabled by this feature.
+Version 1.1 adds the ability to remove whitespace from the clipboard and pressing entered after the input is entered.
 With version 0.1.2 you can switch the hotkey between: 
 - ISO Layout: `left ctrl + left shift + v`
 - DE Layout: `links strg + links shift + v`  

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"golang.design/x/hotkey"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -173,8 +174,12 @@ func textType() {
 	// wait for 500ms before executing
 	time.Sleep(time.Millisecond * 500)
 
-	// use robotgo to type the clipboard text
+	// trim whitespace from the clipboard text
+	clipBoardText = strings.TrimSpace(clipBoardText)
+	// use robotgo to type the clipboard text.
 	robotgo.TypeStr(clipBoardText)
+	// press enter key
+	robotgo.KeyTap("enter")
 	Logger.Println("clipboard entered")
 }
 


### PR DESCRIPTION
Enhanced processing of clipboard data by automatically trimming any leading or trailing whitespaces ensuring accurate typed output. Also, it now simulates pressing 'Enter' key post typing to immediately confirm the input, increasing efficiency.