### PR TITLE
Add contribution guide and refactor README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# How to contribute to Go-TextType
+
+## Did you find a bug?
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/HRA42/Go-TextType/issues).
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/HRA42/Go-TextType/issues/new).
+Be sure to include a **title and clear description**, as much relevant information as possible,
+and a **code sample,** or an **executable test case** demonstrating the expected behavior that is not occurring and add the log file.
+
+## **Did you write a patch that fixes a bug?**
+
+* Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+## Docs
+
+Before you start to contribute, please read the [docs.](https://go-texttype.postrausch.tech/)

--- a/Documentation/docs.tree
+++ b/Documentation/docs.tree
@@ -7,4 +7,5 @@
                  start-page="README.md">
 
     <toc-element topic="README.md"/>
+    <toc-element topic="Contribute.md"/>
 </instance-profile>

--- a/Documentation/topics/Contribute.md
+++ b/Documentation/topics/Contribute.md
@@ -1,0 +1,58 @@
+# Contribute
+
+## How to get started
+
+This guide will help you contribute to the Go-TextType project. Follow the steps below to get started:
+
+### Get the source code from GitHub
+```Bash
+git clone https://github.com/HRA42/Go-TextType.git
+```
+Also, you need to install a C Compiler.
+The steps for installing with MSYS2 (recommended) are:
+- Download and install the latest version of [MSYS2](https://www.msys2.org/#download).
+- Once installed, do not use the MSYS terminal that opens
+- Open “MSYS2 MinGW64” from the start menu
+- Execute the following commands (if asked for installation options, be sure to choose “all”):
+```Bash
+pacman -Syu
+pacman -S git mingw-w64-x86_64-toolchain
+```
+- You will need to add /c/Program\ Files/Go/bin and ~/Go/bin to your $PATH,
+for MSYS2 you can paste the following command into your terminal:
+```Bash
+echo "export PATH=\$PATH:/c/Program\ Files/Go/bin:~/Go/bin" >> ~/.bashrc`
+```
+- For the compiler to work on other terminals, you will need to set up the windows %PATH% variable to find these tools.  
+Go to the “Edit the system environment variables” control panel, tap “Advanced” and add
+“C:\msys64\mingw64\bin” to the Path list.
+
+### Download the dependencies
+```Shell
+```
+{src="make.ps1" include-lines="36-42"}
+
+Or run:
+```Shell
+Powershell.exe -File .\build.ps1 dep
+```
+
+### To build the application
+```Shell
+```
+{src="make.ps1" include-lines="11-20"}
+
+Or run:
+```Bash
+Powershell.exe -File .\build.ps1 build
+```
+
+### To clean the application folder
+```Shell
+```
+{src="make.ps1" include-lines="24-32"}
+
+Or run:
+```Bash
+Powershell.exe -File .\build.ps1 clean
+```

--- a/Documentation/topics/README.md
+++ b/Documentation/topics/README.md
@@ -53,41 +53,7 @@ The required Go packages for this project to function include:
 ## Running the Program
 Download the latest version of the application from the release page.
 
-## Compilation
-Get the source code from GitHub:
-```Bash
-git clone https://github.com/HRA42/Go-TextType.git
-```
 
-Download the dependencies:
-```Shell
-```
-{src="make.ps1" include-lines="36-42"}
-
-Or run:
-```Shell
-Powershell.exe -File .\build.ps1 dep
-```
-
-After you install the dependencies, run:
-```Shell
-```
-{src="make.ps1" include-lines="11-20"}
-
-Or run:
-```Bash
-Powershell.exe -File .\build.ps1 build
-```
-
-When you are ready to start a new build, run:
-```Shell
-```
-{src="make.ps1" include-lines="24-32"}
-
-Or run:
-```Bash
-Powershell.exe -File .\build.ps1 clean
-```
 
 ## Troubleshooting
 The program logs the current version of the application, and the Build ID in its log file TextType.log.

--- a/README.md
+++ b/README.md
@@ -35,41 +35,13 @@ The application is designed to print the text stored in the clipboard.
 It achieves this by calling a hotkey combination that triggers a function in the program.
 This triggered function fetches the content from the clipboard and prints it on the console.
 
-## Dependencies
-The required Go packages for this project to function include:
-- embed for embedding files in executable.
-- encoding/gob for encoding the hotkey and enter preference to a file.
-- github.com/gen2brain/beeep for update notifications.
-- github.com/getlantern/systray for system tray functionality.
-- github.com/go-vgo/robotgo for simulating keyboard inputs.
-- github.com/pkg/browser for opening a browser to the release page on GH.
-- github.com/tcnksm/go-latest for getting the latest version from GH.
-- golang.design/x/clipboard for access to the system clipboard.
-- golang.design/x/hotkey for creating and managing hotkeys.
-
 ## Running the Program
 Download the latest version of the application from the release page.
 
-## Compilation
-Get the source code from GitHub:
-```Bash
-git clone https://github.com/HRA42/Go-TextType.git
-```
-
-Download the dependencies:
-```Shell
-Powershell.exe -File .\build.ps1 dep
-```
-
-After you install the dependencies, run:
-```Bash
-Powershell.exe -File .\build.ps1 build
-```
-
-When you are ready to start a new build, run:
-```Bash
-Powershell.exe -File .\build.ps1 clean
-```
+## Contributing
+If you want to contribute or just compile the app yourself,
+you can follow the [guide.](https://go-texttype.postrausch.tech/contribute.html)
+Before you start to contribute, please read the [contribution file.](./CONTRIBUTING.md)
 
 ## Troubleshooting
 The program logs the current version of the application, and the Build ID in its log file TextType.log.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Go-TextType
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/hra42/Go-TextType)](https://goreportcard.com/report/github.com/hra42/Go-TextType)
+
 > [!Important]
 > Download the latest version from the [release page](https://github.com/HRA42/Go-TextType/releases)
 > and run the executable.  

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities with 
+a [GitHub Issue](https://github.com/HRA42/Go-TextType/issues/new).  
+
+You will receive a response from us within 48 hours.  
+
+If the issue is confirmed, we will release a patch as soon as possible
+depending on complexity but historically within a few days or even hours.


### PR DESCRIPTION
Created a new Contribute.md file which now contains detailed steps on how to clone the repository, set up the environment, download dependencies, build, and clean the application. This information was formerly in README.md, and has been removed there, to prevent redundancy and ensure the README remains concise, focusing on high level project information. The project's document tree (docs.tree) has been updated to include the new Contribute.md file.